### PR TITLE
feature/bky 3073 block on inst creation

### DIFF
--- a/iac/exception.py
+++ b/iac/exception.py
@@ -10,6 +10,7 @@ class IACErrorCode(Enum):
     KEY_DELETE_FAIL = auto()
     DUPLICATE_INSTANCE = auto()
     INSTANCE_NAME_COLLISION = auto()
+    INSTANCE_NOT_RUNNING = auto()
     INSTANCE_TERMINATION_FAIL = auto()
     NO_SUCH_INSTANCE = auto()
     NO_SUCH_INSTANCE_KIND = auto()

--- a/iac/iac.py
+++ b/iac/iac.py
@@ -171,12 +171,14 @@ def instance_create_cmd(ctx):
     fail_on_debug(ctx)
 
     conf = ctx.obj["conf"]
+    ec2 = ctx.obj["ec2"]
     instance = iac.create_instance(
-        ctx.obj["ec2"],
+        ec2,
         iac.InstanceKind.from_str(conf.instance_kind),
         conf.instance_name,
         conf.key_name,
         conf.security_group,
+        iac.instance.InstanceRunningBarrier(ec2),
     )
     console(instance, to_dict=iac.Instance.to_dict)
 

--- a/iac/instance.py
+++ b/iac/instance.py
@@ -161,9 +161,9 @@ class InstanceRunningBarrier(Barrier):
     retry_count: int = 5
 
     def _is_running(self, inst: Instance) -> bool:
-        return inst.state == 'running'
+        return inst.state == "running"
 
-    def _warn(self, msg: str, out=sys.stderr)-> None:
+    def _warn(self, msg: str, out=sys.stderr) -> None:
         out.write(f"**Warning** {msg}")
 
     def wait(self, inst: Instance) -> Instance:
@@ -191,7 +191,7 @@ def create_instance(
     instance_name: str,
     key_name: str,
     security_group: str,
-    barrier:Barrier=Barrier(),
+    barrier: Barrier = Barrier(),
 ) -> Instance:
 
     instances = describe_instances(ec2, instance_name)

--- a/iac/instance.py
+++ b/iac/instance.py
@@ -159,7 +159,7 @@ class Barrier:
 class InstanceRunningBarrier(Barrier):
     ec2: botocore.client.BaseClient
     sleep_time: float = 10
-    retry_count: int = 5
+    retry_count: int = 9
 
     def _is_running(self, inst: Instance) -> bool:
         return inst.state == "running"

--- a/iac/instance.py
+++ b/iac/instance.py
@@ -45,6 +45,7 @@ InstanceSelf = TypeVar("InstanceSelf", bound="Instance")
 
 
 @dataclass(frozen=True)
+# pylint: disable = too-many-instance-attributes
 class Instance:
     name: str
     state: str
@@ -193,7 +194,7 @@ def create_instance(
     security_group: str,
     barrier: Barrier = Barrier(),
 ) -> Instance:
-
+    # pylint: disable = too-many-arguments
     instances = describe_instances(ec2, instance_name)
     if len(instances) != 0:
         raise IACInstanceWarning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ class AWSCannedResponses:
         self.instance_id = "test-instance-id"
         self.instance_name = "test-instance"
         self.instance_public_dns = "test-instance1-dns.compute-1.amazonaws.com"
+        self.instance_public_ip = "34.238.190.126"
         self.key_name = "test-key"
         self.security_group = "test-security-group"
 
@@ -33,6 +34,7 @@ class AWSCannedResponses:
 
     @property
     def instance(self):
+        # resp = self.describe_instances__one_instance
         resp = self.describe_instances__one_instance
         inst = resp["Reservations"][0]["Instances"][0]
         return iac.Instance.from_aws_instance(inst)
@@ -177,14 +179,14 @@ class AWSCannedResponses:
                             "PrivateIpAddress": "172.31.51.34",
                             "ProductCodes": [],
                             "PublicDnsName": self.instance_public_dns,
-                            "PublicIpAddress": "3.235.31.42",
+                            "PublicIpAddress": self.instance_public_ip,
                             "RootDeviceName": "/dev/xvda",
                             "RootDeviceType": "ebs",
                             "SecurityGroups": [
                                 {"GroupId": self.security_group, "GroupName": "some-name"}
                             ],
                             "SourceDestCheck": True,
-                            "State": {"Code": 0, "Name": "pending"},
+                            "State": {"Code": 16, "Name": "running"},
                             "StateTransitionReason": "",
                             "SubnetId": "subnet-d95b9cd7",
                             "Tags": [
@@ -382,7 +384,7 @@ class AWSCannedResponses:
                             "PrivateIpAddress": "172.31.51.163",
                             "ProductCodes": [],
                             "PublicDnsName": self.instance_public_dns,
-                            "PublicIpAddress": "34.238.190.126",
+                            "PublicIpAddress": self.instance_public_ip,
                             "State": {"Code": 16, "Name": "running"},
                             "StateTransitionReason": "",
                             "SubnetId": "subnet-d95b9cd7",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ def pyiac(pytestconfig):
 
 
 class AWSCannedResponses:
+    # pylint: disable = too-many-instance-attributes
     def __init__(self):
         self.instance_id = "test-instance-id"
         self.instance_name = "test-instance"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,6 @@ class AWSCannedResponses:
 
     @property
     def instance(self):
-        # resp = self.describe_instances__one_instance
         resp = self.describe_instances__one_instance
         inst = resp["Reservations"][0]["Instances"][0]
         return iac.Instance.from_aws_instance(inst)

--- a/tests/live/test_workflow.py
+++ b/tests/live/test_workflow.py
@@ -4,6 +4,7 @@ import random
 import string
 import subprocess
 import tempfile
+import time
 
 LOGGER = logging.getLogger(__name__)
 
@@ -94,7 +95,11 @@ def test_iac_workflow__happy_path(pyiac):
 
     info("Checking instance creation")
     instances = iac("instance list")
+    info(instances)
     assert instance_name in {i["name"] for i in instances}
+
+    info("Giving the system some time to startup")
+    time.sleep(10)
 
     with tempfile.NamedTemporaryFile(prefix="bky-iac-") as tmp:
         junk = "".join(random.choices(string.ascii_lowercase, k=5))

--- a/tests/live/test_workflow.py
+++ b/tests/live/test_workflow.py
@@ -40,7 +40,6 @@ class IACRunner:
 
         proc = run(cmd, log_cmd=self.log_cmd)
         assert proc.returncode == 0
-        assert proc.stderr == ""
 
         output = proc.stdout
         return json.loads(output) if output and load_output else {}

--- a/tests/live/test_workflow.py
+++ b/tests/live/test_workflow.py
@@ -95,7 +95,6 @@ def test_iac_workflow__happy_path(pyiac):
 
     info("Checking instance creation")
     instances = iac("instance list")
-    info(instances)
     assert instance_name in {i["name"] for i in instances}
 
     info("Giving the system some time to startup")

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -9,7 +9,7 @@ def test_remote_cmd_runner__from_instance_and_key_file(mock_fabric):
     path = "path"
     username = "username"
 
-    instance = iac.Instance(name="name", public_dns_name=dns_name)
+    instance = iac.Instance(name="name", state="running", public_dns_name=dns_name)
     key_file = iac.KeyFile(path=path, username=username)
 
     iac.RemoteCMDRunner.from_instance_and_key_file(instance, key_file)

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -92,8 +92,7 @@ def test_describe_instances__happy_path_instance_name(aws_parrot):
 
 def test_describe_instances__happy_path_many_instances(aws_parrot):
     ec2 = Mock()
-    ec2.describe_instances.return_value = \
-       aws_parrot.describe_instances__many_instances
+    ec2.describe_instances.return_value = aws_parrot.describe_instances__many_instances
 
     got = iac.instance.describe_instances(ec2)
     assert [aws_parrot.other_instance, aws_parrot.instance] == got
@@ -374,8 +373,7 @@ def test_terminate_instance__cloud_terminate_exception(mock_describe_instances):
 @patch("iac.instance.describe_instances")
 def test_terminate_instance__still_running(mock_describe_instances, aws_parrot):
     ec2 = Mock()
-    ec2.terminate_instances.return_value = \
-        aws_parrot.terminate_instances_result("running")
+    ec2.terminate_instances.return_value = aws_parrot.terminate_instances_result("running")
 
     instance = iac.Instance(name="a", state="running", id="a_id")
     mock_describe_instances.return_value = [instance]
@@ -452,6 +450,7 @@ def test_instance_running_barrier_wait_instance_ok_from_start():
 
     assert got == running
     ec2.assert_not_called()
+
 
 @patch("iac.instance.fetch_instance")
 def test_instance_running_barrier_wait_instance_ok_after_retry(

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -18,9 +18,10 @@ def test_instace_kind__from_str():
     assert "Cannot create instance kind from" in str(e.value)
 
 
-@mark.parametrize("field", ["Tags", "InstanceId", "KeyName", "PublicDnsName"])
+@mark.parametrize("field", ["Tags", "InstanceId", "KeyName"])
 def test_intance__from_aws_instance__error_in_structure(field, aws_parrot):
-    inst = aws_parrot.describe_instances__one_instance["Reservations"][0]["Instances"][0]
+    resp = aws_parrot.describe_instances__one_instance
+    inst = resp["Reservations"][0]["Instances"][0]
     del inst[field]
     with raises(KeyError):
         iac.Instance.from_aws_instance(inst)
@@ -91,7 +92,8 @@ def test_describe_instances__happy_path_instance_name(aws_parrot):
 
 def test_describe_instances__happy_path_many_instances(aws_parrot):
     ec2 = Mock()
-    ec2.describe_instances.return_value = aws_parrot.describe_instances__many_instances
+    ec2.describe_instances.return_value = \
+       aws_parrot.describe_instances__many_instances
 
     got = iac.instance.describe_instances(ec2)
     assert [aws_parrot.other_instance, aws_parrot.instance] == got
@@ -295,7 +297,7 @@ def test_terminate_instance__happy_path(
     ec2 = Mock()
     ec2.terminate_instances.return_value = aws_parrot.terminate_instances_result(state)
 
-    want = iac.Instance(name="a", id="a_id")
+    want = iac.Instance(name="a", state="running", id="a_id")
     mock_describe_instances.return_value = [want]
 
     got = iac.terminate_instance(ec2, want.name)
@@ -341,7 +343,8 @@ def test_terminate_instance__name_collision(mock_describe_instances):
     ec2 = Mock()
 
     instance_name = "a"
-    mock_describe_instances.return_value = [iac.Instance(instance_name)] * 2
+    instance = iac.Instance(name=instance_name, state="running")
+    mock_describe_instances.return_value = [instance] * 2
 
     with raises(iac.IACInstanceError) as exc_info:
         iac.terminate_instance(ec2, instance_name)
@@ -357,7 +360,7 @@ def test_terminate_instance__cloud_terminate_exception(mock_describe_instances):
     ec2 = Mock()
     ec2.terminate_instances.side_effect = want
 
-    instance = iac.Instance(name="a", id="a_id")
+    instance = iac.Instance(name="a", state="running", id="a_id")
     mock_describe_instances.return_value = [instance]
 
     with raises(type(want)) as exc_info:
@@ -371,9 +374,10 @@ def test_terminate_instance__cloud_terminate_exception(mock_describe_instances):
 @patch("iac.instance.describe_instances")
 def test_terminate_instance__still_running(mock_describe_instances, aws_parrot):
     ec2 = Mock()
-    ec2.terminate_instances.return_value = aws_parrot.terminate_instances_result("running")
+    ec2.terminate_instances.return_value = \
+        aws_parrot.terminate_instances_result("running")
 
-    instance = iac.Instance(name="a", id="a_id")
+    instance = iac.Instance(name="a", state="running", id="a_id")
     mock_describe_instances.return_value = [instance]
 
     with raises(iac.IACInstanceError) as exc_info:
@@ -388,7 +392,7 @@ def test_terminate_instance__still_running(mock_describe_instances, aws_parrot):
 def test_list_instances__happy_path(mock_describe_instances):
     ec2 = Mock()
 
-    want = [iac.Instance("a"), iac.Instance("b")]
+    want = [iac.Instance("a", "running"), iac.Instance("b", "running")]
     mock_describe_instances.return_value = want
 
     got = iac.list_instances(ec2)
@@ -401,7 +405,7 @@ def test_list_instances__happy_path(mock_describe_instances):
 def test_fetch_instance__happy_path(mock_describe_instances):
     ec2 = Mock()
 
-    want = iac.Instance("a")
+    want = iac.Instance(name="a", state="running")
     mock_describe_instances.return_value = [want]
 
     got = iac.fetch_instance(ec2, want.name)
@@ -430,10 +434,54 @@ def test_fetch_instance__many_instances(mock_describe_instances):
     ec2 = Mock()
 
     instance_name = "instance_name"
-    mock_describe_instances.return_value = [iac.Instance(instance_name)] * 3
+    instance = iac.Instance(name=instance_name, state="running")
+    mock_describe_instances.return_value = [instance] * 3
 
     with raises(iac.IACInstanceError) as exc_info:
         iac.fetch_instance(ec2, instance_name)
 
     assert exc_info.value.error_code == iac.IACErrorCode.INSTANCE_NAME_COLLISION
     mock_describe_instances.assert_called_once_with(ec2, instance_name)
+
+
+def test_instance_running_barrier_wait_instance_ok_from_start():
+    ec2 = Mock()
+
+    running = iac.Instance(name="inst", state="running")
+    got = iac.instance.InstanceRunningBarrier(ec2, 0, 2).wait(running)
+
+    assert got == running
+    ec2.assert_not_called()
+
+@patch("iac.instance.fetch_instance")
+def test_instance_running_barrier_wait_instance_ok_after_retry(
+    mock_fetch_instance,
+):
+    ec2 = Mock()
+
+    pending = iac.Instance(name="inst", state="pending")
+    running = iac.Instance(name="inst", state="running")
+    mock_fetch_instance.side_effect = [pending, running]
+
+    got = iac.instance.InstanceRunningBarrier(ec2, 0, 2).wait(pending)
+
+    assert got == running
+    assert mock_fetch_instance.call_count == 2
+    ec2.assert_not_called()
+
+
+@patch("iac.instance.fetch_instance")
+def test_instance_running_barrier_wait_instace_stuck_pending(
+    mock_fetch_instance,
+):
+    ec2 = Mock()
+
+    pending = iac.Instance(name="inst", state="pending")
+    mock_fetch_instance.side_effect = [pending, pending]
+
+    with raises(iac.IACInstanceError) as exc_info:
+        iac.instance.InstanceRunningBarrier(ec2, 0, 2).wait(pending)
+
+    assert exc_info.value.error_code == iac.IACErrorCode.INSTANCE_NOT_RUNNING
+    assert mock_fetch_instance.call_count == 2
+    ec2.assert_not_called()


### PR DESCRIPTION
When creating an instance, it can sometimes take some time between AWS getting the request to make the instance and the instance actually being useful (i.e. actually running).  While we can use jq to poll for the state from the `iac instance list` command, that becomes cumbersome and there is no real utility for us to continue any setup until the instance is ready.

This PR adds the default behavior in which iac blocks on creation until the instance is running (or times out waiting).  
While the retry count, sleep time, and the barrier type are configurable in the code, we don't expose those options all the way to the command line, since I don't see a use case for making these user configurable.  Reviewer, if you see a real use case, let me know. It wouldn't be terrible to add to the configuration.