### PR TITLE
Feature/bky 3356 dns not ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Thumbs.db
 *.pem
 /setup/config.toml
 /secrets/*
+/.coverage*

--- a/ned/dns.py
+++ b/ned/dns.py
@@ -1,5 +1,5 @@
-from typing import TypeVar
 from dataclasses import dataclass
+from typing import TypeVar
 
 import botocore.client
 

--- a/ned/exception.py
+++ b/ned/exception.py
@@ -9,7 +9,7 @@ class NEDErrorCode(Enum):
     KEY_MISSING = auto()
     INSTANCE_DUPLICATE = auto()
     INSTANCE_NAME_COLLISION = auto()
-    INSTANCE_NOT_RUNNING = auto()
+    INSTANCE_NOT_READY = auto()
     INSTANCE_MISSING = auto()
     INSTANCE_TERMINATION_FAIL = auto()
     INSTANCE_UNKNOWN_KIND = auto()

--- a/ned/instance.py
+++ b/ned/instance.py
@@ -1,5 +1,5 @@
 import socket
-import subprocess
+import subprocess  # nosec
 import sys
 import time
 from dataclasses import dataclass
@@ -186,8 +186,9 @@ class InstanceReadyBarrier(InstanceBarrier):
         return True
 
     def _ping(self, host: str):
-        command = f"ping -c 1 {host} > /dev/null"
-        return subprocess.run(command, shell=True).returncode == 0
+        command = ["ping", "-c", "1", host]
+        # allow ping through subprocess with nosec
+        return subprocess.call(command, stdout=subprocess.DEVNULL) == 0  # nosec
 
     def _warn(self, msg: str, out=sys.stderr) -> None:
         out.write(f"**Warning** {msg}\n")
@@ -208,7 +209,7 @@ class InstanceReadyBarrier(InstanceBarrier):
         if not ready:
             raise NEDInstanceError(
                 NEDErrorCode.INSTANCE_NOT_READY,
-                f"Instance is not ready",
+                "Instance is not ready",
             )
         return inst
 

--- a/ned/ned.py
+++ b/ned/ned.py
@@ -1,12 +1,11 @@
 import json
-from os.path import join
 from importlib import resources
+from os.path import join
 from pathlib import Path
 
 import click
 
 import ned
-
 
 APP_DATA_PATH = resources.path("ned", "data")
 USER_DATA_PATH = join(Path.home(), ".config", "bky", "ned")
@@ -181,7 +180,7 @@ def instance_create_cmd(ctx):
         conf.instance_name,
         conf.key_name,
         conf.security_group,
-        ned.instance.InstanceRunningBarrier(client.ec2),
+        ned.instance.InstanceReadyBarrier(client.ec2),
     )
     console(instance, to_dict=ned.Instance.to_dict)
 

--- a/ned/ned.py
+++ b/ned/ned.py
@@ -303,7 +303,7 @@ def dns_cmd_create(ctx):
 
 @click.command(name="list")
 @click.pass_context
-def dns_cmd_describe(ctx):
+def dns_cmd_list(ctx):
     fail_on_debug(ctx)
 
     conf = ctx.obj["conf"]
@@ -316,7 +316,7 @@ def dns_cmd_describe(ctx):
 
 @click.command(name="describe")
 @click.pass_context
-def dns_cmd_list(ctx):
+def dns_cmd_describe(ctx):
     fail_on_debug(ctx)
 
     conf = ctx.obj["conf"]

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -10,7 +10,7 @@ class ExpectedUncaughtInstanceException(Exception):
     pass
 
 
-def test_instace_kind__from_str():
+def test_instance_kind__from_str():
     assert ned.InstanceKind.from_str("standard") == ned.InstanceKind.STANDARD
     assert ned.InstanceKind.from_str("nitro") == ned.InstanceKind.NITRO
     with raises(ned.NEDInstanceError) as e:
@@ -455,10 +455,7 @@ def test_instance_ready_barrier_wait_instance_ok_from_start(
     mock_ping.side_effect = [True]
 
     running = ned.Instance(
-        name="inst",
-        state="running",
-        public_dns_name="instance.bky.sh",
-        public_ip_address="1.1.1.1"
+        name="inst", state="running", public_dns_name="instance.bky.sh", public_ip_address="1.1.1.1"
     )
     got = ned.instance.InstanceReadyBarrier(ec2, 0, 0).wait(running)
 
@@ -478,10 +475,7 @@ def test_instance_ready_barrier_wait_instance_ok_after_retry(
 
     pending = ned.Instance(name="inst", state="pending")
     running = ned.Instance(
-        name="inst",
-        state="running",
-        public_dns_name="instance.bky.sh",
-        public_ip_address="1.1.1.1"
+        name="inst", state="running", public_dns_name="instance.bky.sh", public_ip_address="1.1.1.1"
     )
     mock_fetch_instance.side_effect = [running]
     mock_gethostbyname.side_effect = ["1.1.1.1"]
@@ -518,10 +512,7 @@ def test_instance_ready_barrier_wait_host_lookup_error(
     ec2 = Mock()
 
     running = ned.Instance(
-        name="inst",
-        state="running",
-        public_dns_name="instance.bky.sh",
-        public_ip_address="1.1.1.1"
+        name="inst", state="running", public_dns_name="instance.bky.sh", public_ip_address="1.1.1.1"
     )
     mock_gethostbyname.side_effect = [socket.gaierror]
 
@@ -539,10 +530,7 @@ def test_instance_ready_barrier_wait_wrong_ip(
     ec2 = Mock()
 
     running = ned.Instance(
-        name="inst",
-        state="running",
-        public_dns_name="instance.bky.sh",
-        public_ip_address="1.1.1.1"
+        name="inst", state="running", public_dns_name="instance.bky.sh", public_ip_address="1.1.1.1"
     )
     mock_gethostbyname.side_effect = ["2.2.2.2"]
 
@@ -565,10 +553,7 @@ def test_instance_ready_barrier_wait_ping_error(
     mock_ping.side_effect = [False]
 
     running = ned.Instance(
-        name="inst",
-        state="running",
-        public_dns_name="instance.bky.sh",
-        public_ip_address="1.1.1.1"
+        name="inst", state="running", public_dns_name="instance.bky.sh", public_ip_address="1.1.1.1"
     )
     with raises(ned.NEDInstanceError) as exc_info:
         ned.instance.InstanceReadyBarrier(ec2, 0, 0).wait(running)


### PR DESCRIPTION
The problem in https://blocky.atlassian.net/browse/BKY-3356 is that we try to deploy to `instance.public_dns_address` before AWS has finished establishing that DNS mapping for the new instance during `ned instance create`.

In this PR I added a check to the `InstanceBarrier` to make sure that the new instance is can be pinged.